### PR TITLE
build(custom_rules): Branch protection rules added

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,23 @@
 repos:
+-   repo: local
+    hooks:
+    -   id: branch-protection
+        name: branch-protection
+        entry: python custom_rules.py
+        language: python
+        stages:
+        -   pre-commit
+        -   pre-push
+
 -   repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
     -   id: black
+
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.13.0
+    hooks:
+    -   id: isort
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -14,15 +29,15 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0  # Use the ref you want to point at
+    rev: v1.10.0
     hooks:
     -   id: python-no-eval
 
-- repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v3.6.0
-  hooks:
-    - id: conventional-pre-commit
-      stages: [commit-msg]
-      args: [--strict, ]
+-   repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+    -   id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [--strict, ]
 
 default_install_hook_types: [pre-commit, pre-push, commit-msg]

--- a/custom_rules.py
+++ b/custom_rules.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+
+
+class CommitException(Exception):
+    def __init__(self, message="Invalid commit"):
+        super().__init__(message)
+
+
+def validate_commit():
+    command = "git branch --show-current"
+    branch = subprocess.run(command, capture_output=True, text=True).stdout.strip()
+
+    if branch == "production" or branch == "master":
+        raise CommitException(
+            f"Direct commit or push to {branch} isn't allowed. Please raise PR from {"production" if branch=="master" else "development"}"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        validate_commit()
+        sys.exit(0)
+    except Exception as error:
+        print(error)
+        sys.exit(1)


### PR DESCRIPTION
In this commit new rule added to protect master and production branch. As per the rules developer aren't allowed to commit and push code directly to those branches without PR. To enforce this rules new custom_rule python file added.

BREAKING CHANGE: Direct code push and commit on production and master branch are not allowed anymore.